### PR TITLE
Extract clearbit.Client and add lookup command

### DIFF
--- a/client.go
+++ b/client.go
@@ -5,12 +5,14 @@ import (
 	"net/url"
 )
 
+// These are the valid services and resources of the Clearbit API.
 const (
 	ProspectorPersonSearchURL = "https://prospector.clearbit.com/v1/people/search"
 	StreamingCompanySearchURL = "https://company-stream.clearbit.com/v2/companies/find"
 	StreamingPersonSearchURL  = "https://person-stream.clearbit.com/v2/people/find"
 )
 
+// Client provides access to the Clearbit API.
 type Client struct {
 	apiKey string
 

--- a/cmd/clearbit/enrich.go
+++ b/cmd/clearbit/enrich.go
@@ -1,0 +1,49 @@
+package main
+
+import (
+	"io"
+	"net/url"
+	"os"
+	"strings"
+
+	"github.com/codegangsta/cli"
+	"github.com/thoughtbot/clearbit"
+)
+
+var enrichCommand = cli.Command{
+	Name:      "enrich",
+	Usage:     "enrich a person or company",
+	ArgsUsage: "email or domain",
+	Action:    enrich,
+}
+
+func enrich(ctx *cli.Context) {
+	var (
+		apiKey = apiKeyFromContext(ctx)
+		token  = requiredArg(ctx, 0)
+	)
+
+	client := clearbit.NewClient(apiKey)
+
+	endpoint, params := prepareLookupRequest(token)
+
+	res, err := client.Get(endpoint, params)
+	if err != nil {
+		abort(err)
+	}
+	defer res.Body.Close()
+
+	io.Copy(os.Stdout, res.Body)
+}
+
+func prepareLookupRequest(token string) (string, url.Values) {
+	if isEmail(token) {
+		return clearbit.StreamingPersonSearchURL, url.Values{"email": {token}}
+	}
+
+	return clearbit.StreamingCompanySearchURL, url.Values{"domain": {token}}
+}
+
+func isEmail(s string) bool {
+	return strings.Contains(s, "@")
+}

--- a/cmd/clearbit/prospect.go
+++ b/cmd/clearbit/prospect.go
@@ -1,0 +1,48 @@
+package main
+
+import (
+	"fmt"
+	"io"
+	"net/url"
+	"os"
+
+	"github.com/codegangsta/cli"
+	"github.com/thoughtbot/clearbit"
+)
+
+var prospectCommand = cli.Command{
+	Name:      "prospect",
+	Usage:     "fetch contacts for a company",
+	ArgsUsage: "domain",
+	Action:    prospect,
+	Flags: []cli.Flag{
+		cli.StringSliceFlag{Name: "title", Usage: "Job title to filter by"},
+		cli.BoolTFlag{Name: "email", Usage: "Include contact emails"},
+	},
+}
+
+func prospect(ctx *cli.Context) {
+	var (
+		apiKey       = apiKeyFromContext(ctx)
+		domain       = requiredArg(ctx, 0)
+		titles       = ctx.StringSlice("title")
+		includeEmail = ctx.BoolT("email")
+	)
+
+	client := clearbit.NewClient(apiKey)
+
+	res, err := client.Get(
+		clearbit.ProspectorPersonSearchURL,
+		url.Values{
+			"domain":   []string{domain},
+			"email":    []string{fmt.Sprintf("%t", includeEmail)},
+			"titles[]": titles,
+		},
+	)
+	if err != nil {
+		abort(err)
+	}
+	defer res.Body.Close()
+
+	io.Copy(os.Stdout, res.Body)
+}


### PR DESCRIPTION
This adds support for the person and company search APIs in clearbit:

```
clearbit lookup b@thoughtbot.com
clearbit lookup thoughtbot.com
```

It also starts to extract some Clearbit client logic into the root `clearbit` package and out of the command-line tool.
