### PR TITLE
Add Company, Person, and ErrorResponse structs

### DIFF
--- a/fixtures/enrichment_company_response.json
+++ b/fixtures/enrichment_company_response.json
@@ -1,0 +1,97 @@
+{
+  "id": "027b0d40-016c-40ea-8925-a076fa640992",
+  "name": "Uber",
+  "legalName": "Uber, Inc.",
+  "domain": "uber.com",
+  "domainAliases": [],
+  "url": "http://uber.com",
+  "site": {
+    "url": "http://uber.com",
+    "title": null,
+    "h1": null,
+    "metaDescription": null,
+    "metaAuthor": null,
+    "phoneNumbers": [
+      "+1 877-223-8023"
+    ],
+    "emailAddresses": [
+      "team@uber.com"
+    ]
+  },
+  "tags": [
+    "Transportation",
+    "Design",
+    "SEO",
+    "Automotive",
+    "Real Time",
+    "Limousines",
+    "Public Transportation",
+    "Transport"
+  ],
+  "description": "Uber is a mobile app connecting passengers with drivers for hire.",
+  "foundedDate": "2009-03-01",
+  "location": "1455 Market Street, San Francisco, CA 94103, USA",
+  "timeZone": "America/Los_Angeles",
+  "utcOffset": -8,
+  "geo": {
+    "streetNumber": "1455",
+    "streetName": "Market Street",
+    "subPremise": null,
+    "city": "San Francisco",
+    "state": "California",
+    "stateCode": "CA",
+    "postalCode": "94103",
+    "country": "United States",
+    "countryCode": "US",
+    "lat": 37.7752315,
+    "lng": -122.4175567
+  },
+  "metrics": {
+    "raised": 5900000000,
+    "employees": 3250,
+    "googleRank": 7,
+    "alexaUsRank": 649,
+    "alexaGlobalRank": 1071,
+    "marketCap": null,
+    "annualRevenue": null
+  },
+  "logo": "https://dqus23xyrtg1i.cloudfront.net/v1/logos/027b0d40-016c-40ea-8925-a076fa640992",
+  "facebook": {
+    "handle": "uber.IND"
+  },
+  "linkedin": {
+    "handle": "company/uber.com"
+  },
+  "twitter": {
+    "handle": "uber",
+    "id": 19103481,
+    "bio": "Everyone's Private Driver. Question, concern or praise? Tweet at your local community manager here: https://t.co/EUiTjLk0xj",
+    "followers": 176582,
+    "following": 330,
+    "location": "Global",
+    "site": "http://t.co/PtMbwFTeQA",
+    "avatar": "https://pbs.twimg.com/profile_images/378800000762572812/91ea09a6535666e18ca3c56f731f67ef_normal.jpeg"
+  },
+  "angellist": {
+    "id": 19163,
+    "handle": "uber",
+    "description": "Request a car from any mobile phone via text message, iPhone and Android apps. Within minutes, a professional driver in a sleek black car will arrive curbside. Automatically charged to your credit card on file, tip included.",
+    "followers": 2650,
+    "blogUrl": "http://blog.uber.com/"
+  },
+  "crunchbase": {
+    "handle": "uber"
+  },
+  "phone": "+1 877-223-8023",
+  "emailProvider": false,
+  "type": "private",
+  "tech": [
+    "google_analytics",
+    "double_click",
+    "mixpanel",
+    "optimizely",
+    "typekit_by_adobe",
+    "nginx",
+    "google_apps"
+  ]
+}

--- a/fixtures/enrichment_person_response.json
+++ b/fixtures/enrichment_person_response.json
@@ -1,0 +1,89 @@
+{
+  "id": "d54c54ad-40be-4305-8a34-0ab44710b90d",
+  "name": {
+    "fullName": "Alex MacCaw",
+    "givenName": "Alex",
+    "familyName": "MacCaw"
+  },
+  "email": "alex@alexmaccaw.com",
+  "gender": "male",
+  "location": "San Francisco, CA, US",
+  "timeZone": "America/Los_Angeles",
+  "utcOffset": -8,
+  "geo": {
+    "city": "San Francisco",
+    "state": "California",
+    "stateCode": "CA",
+    "country": "United States",
+    "countryCode": "US",
+    "lat": 37.7749295,
+    "lng": -122.4194155
+  },
+  "bio": "O'Reilly author, software engineer & traveller. Founder of https://clearbit.com",
+  "site": "http://alexmaccaw.com",
+  "avatar": "https://d1ts43dypk8bqh.cloudfront.net/v1/avatars/d54c54ad-40be-4305-8a34-0ab44710b90d",
+  "employment": {
+    "domain": "clearbit.com",
+    "name": "Clearbit",
+    "title": "Founder and CEO",
+    "role": "ceo",
+    "seniority": "executive"
+  },
+  "facebook": {
+    "handle": "amaccaw"
+  },
+  "github": {
+    "handle": "maccman",
+    "avatar": "https://avatars.githubusercontent.com/u/2142?v=2",
+    "company": "Clearbit",
+    "blog": "http://alexmaccaw.com",
+    "followers": 2932,
+    "following": 94
+  },
+  "twitter": {
+    "handle": "maccaw",
+    "id": "2006261",
+    "bio": "O'Reilly author, software engineer & traveller. Founder of https://clearbit.com",
+    "followers": 15248,
+    "following": 1711,
+    "location": "San Francisco",
+    "site": "http://alexmaccaw.com",
+    "avatar": "https://pbs.twimg.com/profile_images/1826201101/297606_10150904890650705_570400704_21211347_1883468370_n.jpeg"
+  },
+  "linkedin": {
+    "handle": "pub/alex-maccaw/78/929/ab5"
+  },
+  "googleplus": {
+    "handle": null
+  },
+  "angellist": {
+    "handle": "maccaw",
+    "bio": "O'Reilly author, engineer & traveller. Mostly harmless.",
+    "blog": "http://blog.alexmaccaw.com",
+    "site": "http://alexmaccaw.com",
+    "followers": 532,
+    "avatar": "https://d1qb2nb5cznatu.cloudfront.net/users/403357-medium_jpg?1405661263"
+  },
+  "aboutme": {
+    "handle": "maccaw",
+    "bio": "Software engineer & traveller. Walker, skier, reader, tennis player, breather, ginger beer drinker, scooterer & generally enjoying things :)",
+    "avatar": "http://o.aolcdn.com/dims-global/dims/ABOUTME/5/803/408/80/http://d3mod6n032mdiz.cloudfront.net/thumb2/m/a/c/maccaw/maccaw-840x560.jpg"
+  },
+  "gravatar": {
+    "handle": "maccman",
+    "urls": [
+      {
+        "value": "http://alexmaccaw.com",
+        "title": "Personal Website"
+      }
+    ],
+    "avatar": "http://2.gravatar.com/avatar/994909da96d3afaf4daaf54973914b64",
+    "avatars": [
+      {
+        "url": "http://2.gravatar.com/avatar/994909da96d3afaf4daaf54973914b64",
+        "type": "thumbnail"
+      }
+    ]
+  },
+  "fuzzy": false
+}

--- a/fixtures/error_response.json
+++ b/fixtures/error_response.json
@@ -1,0 +1,6 @@
+{
+  "error": {
+    "type": "params_invalid",
+    "message": "Name is required"
+  }
+}

--- a/fixtures_test.go
+++ b/fixtures_test.go
@@ -1,0 +1,18 @@
+package clearbit_test
+
+import (
+	"encoding/json"
+	"io/ioutil"
+	"path"
+)
+
+func unmarshalFixture(name string, v interface{}) error {
+	fixtureFilename := path.Join("fixtures", name) + ".json"
+
+	data, err := ioutil.ReadFile(fixtureFilename)
+	if err != nil {
+		return err
+	}
+
+	return json.Unmarshal(data, v)
+}

--- a/types.go
+++ b/types.go
@@ -1,0 +1,248 @@
+package clearbit
+
+import (
+	"encoding/json"
+	"strconv"
+)
+
+// Company describes company data known to Clearbit.
+//
+// https://clearbit.com/docs#enrichment-api-company-api-attributes
+type Company struct {
+	Description   string         `json:"description"`
+	Domain        string         `json:"domain"`
+	DomainAliases []string       `json:"domainAliases"`
+	EmailProvider bool           `json:"emailProvider"`
+	FoundedDate   string         `json:"foundedDate"`
+	Geo           Geo            `json:"geo"`
+	ID            string         `json:"id"`
+	LegalName     string         `json:"legalName"`
+	Location      string         `json:"location"`
+	Logo          string         `json:"logo"`
+	Metrics       CompanyMetrics `json:"metrics"`
+	Name          string         `json:"name"`
+	Phone         string         `json:"phone"`
+	Site          CompanySite    `json:"site"`
+	Tags          []string       `json:"tags"`
+	Tech          []string       `json:"tech"`
+	TimeZone      string         `json:"timeZone"`
+	Type          string         `json:"type"`
+	URL           string         `json:"url"`
+	UTCOffset     int            `json:"utcOffset"`
+
+	AngelList  AngelListProfile  `json:"angellist"`
+	CrunchBase CrunchBaseProfile `json:"crunchbase"`
+	Facebook   FacebookProfile   `json:"facebook"`
+	LinkedIn   LinkedInProfile   `json:"linkedin"`
+	Twitter    TwitterProfile    `json:"twitter"`
+}
+
+// CompanySite describes information about and from a company's site.
+type CompanySite struct {
+	EmailAddresses  []string `json:"emailAddresses"`
+	H1              string   `json:"h1"`
+	MetaAuthor      string   `json:"metaAuthor"`
+	MetaDescription string   `json:"metaDescription"`
+	PhoneNumbers    []string `json:"phoneNumbers"`
+	Title           string   `json:"title"`
+	URL             string   `json:"url"`
+}
+
+// CompanyMetrics describes a company's metrics across different sites,
+// services, and other metrics.
+type CompanyMetrics struct {
+	AlexaGlobalRank int `json:"alexaGlobalRank"`
+	AlexaUsRank     int `json:"alexaUsRank"`
+	AnnualRevenue   int `json:"annualRevenue"`
+	Employees       int `json:"employees"`
+	GoogleRank      int `json:"googleRank"`
+	MarketCap       int `json:"marketCap"`
+	Raised          int `json:"raised"`
+}
+
+// Person describes person data known to Clearbit.
+//
+// https://clearbit.com/docs#enrichment-api-person-api-attributes
+type Person struct {
+	Avatar     string     `json:"avatar"`
+	Bio        string     `json:"bio"`
+	Email      string     `json:"email"`
+	Employment Employment `json:"employment"`
+	Fuzzy      bool       `json:"fuzzy"`
+	Gender     string     `json:"gender"`
+	Geo        Geo        `json:"geo"`
+	ID         string     `json:"id"`
+	Location   string     `json:"location"`
+	Name       Name       `json:"name"`
+	Site       string     `json:"site"`
+	TimeZone   string     `json:"timeZone"`
+	UTCOffset  int        `json:"utcOffset"`
+
+	AboutMe    AboutMeProfile    `json:"aboutme"`
+	AngelList  AngelListProfile  `json:"angellist"`
+	Facebook   FacebookProfile   `json:"facebook"`
+	GitHub     GitHubProfile     `json:"github"`
+	GooglePlus GooglePlusProfile `json:"googleplus"`
+	Gravatar   GravatarProfile   `json:"gravatar"`
+	Twitter    TwitterProfile    `json:"twitter"`
+	LinkedIn   LinkedInProfile   `json:"linkedin"`
+}
+
+// Name describes a person's name.
+type Name struct {
+	FamilyName string `json:"familyName"`
+	FullName   string `json:"fullName"`
+	GivenName  string `json:"givenName"`
+}
+
+// Employment describes a person's current employment status.
+type Employment struct {
+	Domain    string `json:"domain"`
+	Name      string `json:"name"`
+	Role      string `json:"role"`
+	Seniority string `json:"seniority"`
+	Title     string `json:"title"`
+}
+
+// Geo represents a person or comapny's location.
+//
+// Some fields are only available for companies.
+type Geo struct {
+	City         string  `json:"city"`
+	Country      string  `json:"country"`
+	CountryCode  string  `json:"countryCode"`
+	Lat          float64 `json:"lat"`
+	Lng          float64 `json:"lng"`
+	PostalCode   string  `json:"postalCode"`
+	State        string  `json:"state"`
+	StateCode    string  `json:"stateCode"`
+	StreetName   string  `json:"streetName"`
+	StreetNumber string  `json:"streetNumber"`
+	SubPremise   string  `json:"subPremise"`
+}
+
+// AboutMeProfile describes a person's About.me profile.
+type AboutMeProfile struct {
+	Avatar string `json:"avatar"`
+	Bio    string `json:"bio"`
+	Handle string `json:"handle"`
+}
+
+// AngelListProfile describes a person or company's AngelList profile.
+type AngelListProfile struct {
+	Avatar    string `json:"avatar"`
+	Bio       string `json:"bio"`
+	Blog      string `json:"blog"`
+	Followers int    `json:"followers"`
+	Handle    string `json:"handle"`
+	ID        int    `json:"id"`
+	Site      string `json:"site"`
+}
+
+// CrunchBaseProfile describes a company's CrunchBase profile.
+type CrunchBaseProfile struct {
+	Handle string `json:"handle"`
+}
+
+// FacebookProfile describes a person or company's Facebook profile.
+type FacebookProfile struct {
+	Handle string `json:"handle"`
+}
+
+// GitHubProfile describes a person's GitHub profile.
+type GitHubProfile struct {
+	Avatar    string `json:"avatar"`
+	Blog      string `json:"blog"`
+	Company   string `json:"company"`
+	Followers int    `json:"followers"`
+	Following int    `json:"following"`
+	Handle    string `json:"handle"`
+}
+
+// GooglePlusProfile describes a person's Google+ profile.
+type GooglePlusProfile struct {
+	Handle string `json:"handle"`
+}
+
+// GravatarProfile describes a person's public Gravatar profile.
+type GravatarProfile struct {
+	DefaultAvatarURL string           `json:"avatar"`
+	Avatars          []GravatarAvatar `json:"avatars"`
+	Handle           string           `json:"handle"`
+	URLs             []GravatarURL    `json:"urls"`
+}
+
+// GravatarAvatar describes an avatar associated with a person's Gravatar
+// profile. For example, the type may be "thumbnail" and the URL to view it.
+type GravatarAvatar struct {
+	Type string `json:"type"`
+	URL  string `json:"url"`
+}
+
+// GravatarURL describes a URL associated with a person's Gravatar profile,
+// like a link to their blog.
+type GravatarURL struct {
+	Title string `json:"title"`
+	Value string `json:"value"`
+}
+
+// LinkedInProfile describes a person or company's public LinkedIn profile.
+type LinkedInProfile struct {
+	Handle string `json:"handle"`
+}
+
+// TwitterProfile describes a person or company's public Twitter profile.
+type TwitterProfile struct {
+	Avatar    string    `json:"avatar"`
+	Bio       string    `json:"bio"`
+	Followers int       `json:"followers"`
+	Following int       `json:"following"`
+	Handle    string    `json:"handle"`
+	ID        TwitterID `json:"id"`
+	Location  string    `json:"location"`
+	Site      string    `json:"site"`
+}
+
+// TwitterID is a person or company's Twitter profile ID.
+//
+// It is stored as a string, though it can be also be an integer
+// in Clearbit API responses.
+type TwitterID string
+
+// UnmarshalJSON implements json.Unmarshaler.
+func (id *TwitterID) UnmarshalJSON(data []byte) error {
+	if err := id.unmarshalString(data); err != nil {
+		return id.unmarshalInt(data)
+	}
+
+	return nil
+}
+
+func (id *TwitterID) unmarshalString(data []byte) error {
+	return json.Unmarshal(data, (*string)(id))
+}
+
+func (id *TwitterID) unmarshalInt(data []byte) error {
+	var intID int
+
+	if err := json.Unmarshal(data, &intID); err != nil {
+		return err
+	}
+
+	*id = TwitterID(strconv.Itoa(intID))
+	return nil
+}
+
+// ErrorResponse describes the structure of non-successful responses from the
+// Clearbit API.
+type ErrorResponse struct {
+	Error `json:"error"`
+}
+
+// Error describes an error returned by Clearbit's API.
+//
+// For a list of error types, see https://clearbit.com/docs#errors-error-types.
+type Error struct {
+	Type    string `json:"type"`
+	Message string `json:"message"`
+}

--- a/types_test.go
+++ b/types_test.go
@@ -1,0 +1,66 @@
+package clearbit_test
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/thoughtbot/clearbit"
+)
+
+func TestEnrichmentPersonResponse(t *testing.T) {
+	var person clearbit.Person
+
+	if err := unmarshalFixture("enrichment_person_response", &person); err != nil {
+		t.Fatal("Failed to unmarshal:", err)
+	}
+
+	if person.ID == "" {
+		t.Fatal("Expected person to be present")
+	}
+}
+
+func TestEnrichmentCompanyResponse(t *testing.T) {
+	var company clearbit.Company
+
+	if err := unmarshalFixture("enrichment_company_response", &company); err != nil {
+		t.Fatal("Failed to unmarshal:", err)
+	}
+
+	if company.ID == "" {
+		t.Fatal("Expected company to be present")
+	}
+}
+
+func TestErrorResponse(t *testing.T) {
+	var error clearbit.ErrorResponse
+
+	if err := unmarshalFixture("error_response", &error); err != nil {
+		t.Fatal("Failed to unmarshal:", err)
+	}
+
+	if error.Type != "params_invalid" {
+		t.Fatal("Expected error to be unmarshaled")
+	}
+}
+
+func TestTwitterID(t *testing.T) {
+	var id clearbit.TwitterID
+
+	data := []byte(`123`)
+	if err := json.Unmarshal(data, &id); err != nil {
+		t.Fatalf("Failed to unmarshal %q into TwitterID: %s", data, err)
+	}
+
+	if id != "123" {
+		t.Fatalf("Unmarshaled id = %v, want %v", id, "123")
+	}
+
+	data = []byte(`"321"`)
+	if err := json.Unmarshal(data, &id); err != nil {
+		t.Fatalf("Failed to unmarshal %q into TwitterID: %s", data, err)
+	}
+
+	if id != "321" {
+		t.Fatalf("Unmarshaled id = %v, want %v", id, "321")
+	}
+}


### PR DESCRIPTION
We want to be able to programatically extract more detailed information
from Clearbit API responses, which requires we have data types that map
the API responses.

This adds `Company`, `Person`, and `ErrorResponse` types, and additional
types needed to represent all of the data returned from Clearbit for
these types.

The structs were generated from the fixtures with [gojson](github.com/ChimeraCoder/gojson/gojson), and then
edited for human consumption.

The only special type introduced here is `TwitterID`. It does some extra
work when unmarshaling from responses to handle the fact that Clearbit
is inconsistent about returning Twitter IDs as integers or strings.
