### PR TITLE
Update circle.yml for Go 1.6/1.5 compatibility

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -1,20 +1,14 @@
-# See https://robots.thoughtbot.com/configure-circleci-for-go
 machine:
   environment:
-    IMPORT_PATH: "github.com/$CIRCLE_PROJECT_USERNAME/$CIRCLE_PROJECT_REPONAME"
-    MYGOPATH: "$(echo $GOPATH | cut -d : -f 1)"
+    GO15VENDOREXPERIMENT: "1"
 
 dependencies:
-  pre:
-    - go get github.com/tools/godep
-
   override:
-    - mkdir -p "$MYGOPATH/src/$IMPORT_PATH"
-    - rsync -azC --delete ./ "$MYGOPATH/src/$IMPORT_PATH/"
+    - bin/setup
 
 test:
   pre:
     - bin/vet
 
   override:
-    - godep go test ./...
+    - go test ./...


### PR DESCRIPTION
The previous `circle.yml` was failing because CircleCI still provides
Go 1.5, but development is happening with Go 1.6.

This simplifies the setup a bit while supporting the mixed environment.
