### PR TITLE
Add EnrichCompany method on Client

### DIFF
--- a/client.go
+++ b/client.go
@@ -55,14 +55,29 @@ func (c *Client) Get(endpoint string, params url.Values) (*http.Response, error)
 // EnrichPerson finds a person by their email address
 // and returns detailed information about them.
 func (c *Client) EnrichPerson(email string) (*Person, error) {
-	params := url.Values{
-		"email": []string{email},
-	}
-
 	var person *Person
-	err := c.get(EnrichPersonStreamingURL, params, &person)
+
+	err := c.get(
+		EnrichPersonStreamingURL,
+		url.Values{"email": []string{email}},
+		&person,
+	)
 
 	return person, err
+}
+
+// EnrichCompany finds a company by its domain
+// and returns detailed information about it.
+func (c *Client) EnrichCompany(domain string) (*Company, error) {
+	var company *Company
+
+	err := c.get(
+		EnrichCompanyStreamingURL,
+		url.Values{"domain": []string{domain}},
+		&company,
+	)
+
+	return company, err
 }
 
 func (c *Client) get(endpoint string, params url.Values, v interface{}) error {

--- a/cmd/clearbit/main.go
+++ b/cmd/clearbit/main.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"bytes"
+	"encoding/json"
 	"fmt"
 	"io/ioutil"
 	"os"
@@ -66,6 +67,13 @@ func requiredArg(ctx *cli.Context, n int) string {
 	}
 
 	return arg
+}
+
+func display(item interface{}) {
+	data, _ := json.MarshalIndent(item, "", "  ")
+
+	os.Stdout.Write(data)
+	os.Stdout.Write([]byte("\n"))
 }
 
 func abort(reason interface{}) {


### PR DESCRIPTION
This adds an `EnrichCompany` method to the Clearbit client for getting
structured information about a company from its domain name.

This implements the proposal in #9, except that it only accepts a domain
name argument, because we don't currently have any cases where we use
non-streaming calls or pass extra options.

The `enrich` subcommand of the clearbit CLI is also updated to use the
new client API.
