### PR TITLE
Add Prospect method for finding company contacts

### DIFF
--- a/cmd/clearbit/prospect.go
+++ b/cmd/clearbit/prospect.go
@@ -1,10 +1,6 @@
 package main
 
 import (
-	"io"
-	"net/url"
-	"os"
-
 	"github.com/codegangsta/cli"
 	"github.com/thoughtbot/clearbit"
 )
@@ -30,19 +26,13 @@ func prospect(ctx *cli.Context) {
 
 	client := clearbit.NewClient(apiKey, nil)
 
-	res, err := client.Get(
-		clearbit.ProspectURL,
-		url.Values{
-			"domain":   []string{domain},
-			"email":    []string{"true"},
-			"name":     []string{name},
-			"titles[]": titles,
-		},
-	)
+	prospects, err := client.Prospect(clearbit.ProspectQuery{
+		Domain: domain,
+		Name:   name,
+		Titles: titles,
+	})
 	if err != nil {
 		abort(err)
 	}
-	defer res.Body.Close()
-
-	io.Copy(os.Stdout, res.Body)
+	display(prospects)
 }

--- a/fixtures/prospect_response.json
+++ b/fixtures/prospect_response.json
@@ -1,0 +1,12 @@
+[
+  {
+    "id": "p_2d573999-8a4d-42cc-b47d-c7795adfd7df",
+    "name": {
+      "familyName": "Doe",
+      "fullName": "Jane Doe",
+      "givenName": "Jane"
+    },
+    "title": "CEO",
+    "email": "jane@example.com"
+  }
+]

--- a/types.go
+++ b/types.go
@@ -88,6 +88,17 @@ type Person struct {
 	LinkedIn   LinkedInProfile   `json:"linkedin"`
 }
 
+// Prospect describes the basic contact information for a person
+// found through the Prospector API.
+//
+// https://clearbit.com/docs#prospector-api-person-search-response-body
+type Prospect struct {
+	ID    string `json:"id"`
+	Name  Name   `json:"name"`
+	Title string `json:"title"`
+	Email string `json:"email"`
+}
+
 // Name describes a person's name.
 type Name struct {
 	FamilyName string `json:"familyName"`


### PR DESCRIPTION
This adds a `Prospect` method to `Client` for finding contacts at a
company.

The `clearbit` command is now implemented entirely through normal
`Client` calls.

This is the final implementation of features outlined in #9.
