### PR TITLE
Release clearbit version 0.1

### DIFF
--- a/cmd/clearbit/main.go
+++ b/cmd/clearbit/main.go
@@ -22,6 +22,7 @@ func main() {
 	app.Flags = []cli.Flag{
 		cli.StringFlag{Name: "api-key", Usage: "clearbit API key (default ~/.clearbit_key)", Destination: &clearbitKey},
 	}
+	app.Version = "0.1"
 
 	app.Commands = []cli.Command{
 		enrichCommand,


### PR DESCRIPTION
Release notes:

> This releases version 0.1 of the clearbit command! It features:
>
>   * Save your key in `~/.clearbit_key` to always have it around
>   * Look up companies with `clearbit enrich [domain]`
>   * Look up people with `clearbit enrich [email]`
>   * Find contacts at a company with `clearbit prospect [domain]`

This can be merged after #14 and #15, and the project is made public.

The notes should be attached to a release tag. Once that's done, we can add a
new formula to thoughtbot/homebrew-formulae for easy installation.