### PR TITLE
Update clearbit command for latest CLI package

### DIFF
--- a/cmd/clearbit/enrich.go
+++ b/cmd/clearbit/enrich.go
@@ -14,18 +14,25 @@ var enrichCommand = cli.Command{
 	Action:    enrich,
 }
 
-func enrich(ctx *cli.Context) {
+func enrich(ctx *cli.Context) error {
 	var (
 		apiKey = apiKeyFromContext(ctx)
-		query  = requiredArg(ctx, 0)
 		client = clearbit.NewClient(apiKey, nil)
+
+		query = ctx.Args().First()
 	)
+
+	if query == "" {
+		return requiredArgError("Usage: clearbit enrich <email|domain>")
+	}
 
 	item, err := enrichPersonOrCompany(client, query)
 	if err != nil {
-		abort(err)
+		return exitError(err)
 	}
+
 	display(item)
+	return nil
 }
 
 func enrichPersonOrCompany(c *clearbit.Client, query string) (interface{}, error) {

--- a/cmd/clearbit/main.go
+++ b/cmd/clearbit/main.go
@@ -3,7 +3,6 @@ package main
 import (
 	"bytes"
 	"encoding/json"
-	"fmt"
 	"io/ioutil"
 	"os"
 	"os/user"
@@ -28,7 +27,8 @@ func main() {
 		enrichCommand,
 		prospectCommand,
 	}
-	app.RunAndExitOnError()
+
+	app.Run(os.Args)
 }
 
 func clearbitKeyLoader(key *string) func(*cli.Context) error {
@@ -59,15 +59,8 @@ func apiKeyFromContext(ctx *cli.Context) string {
 	return ctx.GlobalString("api-key")
 }
 
-func requiredArg(ctx *cli.Context, n int) string {
-	arg := ctx.Args().Get(n)
-
-	if arg == "" {
-		cli.ShowSubcommandHelp(ctx)
-		os.Exit(1)
-	}
-
-	return arg
+func requiredArgError(msg string) error {
+	return cli.NewExitError(msg, 1)
 }
 
 func display(item interface{}) {
@@ -77,7 +70,6 @@ func display(item interface{}) {
 	os.Stdout.Write([]byte("\n"))
 }
 
-func abort(reason interface{}) {
-	fmt.Printf("ERROR: %s\n", reason)
-	os.Exit(1)
+func exitError(err error) error {
+	return cli.NewExitError(err.Error(), 1)
 }

--- a/cmd/clearbit/prospect.go
+++ b/cmd/clearbit/prospect.go
@@ -16,15 +16,19 @@ var prospectCommand = cli.Command{
 	},
 }
 
-func prospect(ctx *cli.Context) {
+func prospect(ctx *cli.Context) error {
 	var (
 		apiKey = apiKeyFromContext(ctx)
-		domain = requiredArg(ctx, 0)
+		client = clearbit.NewClient(apiKey, nil)
+
+		domain = ctx.Args().First()
 		name   = ctx.String("name")
 		titles = ctx.StringSlice("title")
 	)
 
-	client := clearbit.NewClient(apiKey, nil)
+	if domain == "" {
+		return requiredArgError("Usage: clearbit prospect <domain>")
+	}
 
 	prospects, err := client.Prospect(clearbit.ProspectQuery{
 		Domain: domain,
@@ -32,7 +36,9 @@ func prospect(ctx *cli.Context) {
 		Titles: titles,
 	})
 	if err != nil {
-		abort(err)
+		return exitError(err)
 	}
+
 	display(prospects)
+	return nil
 }


### PR DESCRIPTION
The latest version of codegangsta/cli deprecates the
`RunAndExitOnError()` method for applications, instead encouraging apps
to return errors to signal the exit strategy.

This updates the clearbit command to build and run without deprecation
warnings.