### PR TITLE
Update {codegangsta,urfave}/cli reference

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,4 +1,4 @@
-Copyright (c) 2016 Bernerd Schaefer and thoughtbot, inc.
+Copyright (c) 2016-2017 Bernerd Schaefer and thoughtbot, inc.
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/cmd/clearbit/enrich.go
+++ b/cmd/clearbit/enrich.go
@@ -3,8 +3,8 @@ package main
 import (
 	"strings"
 
-	"github.com/codegangsta/cli"
 	"github.com/thoughtbot/clearbit"
+	"gopkg.in/urfave/cli.v1"
 )
 
 var enrichCommand = cli.Command{

--- a/cmd/clearbit/main.go
+++ b/cmd/clearbit/main.go
@@ -8,7 +8,7 @@ import (
 	"os/user"
 	"path"
 
-	"github.com/codegangsta/cli"
+	"gopkg.in/urfave/cli.v1"
 )
 
 func main() {

--- a/cmd/clearbit/prospect.go
+++ b/cmd/clearbit/prospect.go
@@ -1,8 +1,8 @@
 package main
 
 import (
-	"github.com/codegangsta/cli"
 	"github.com/thoughtbot/clearbit"
+	"gopkg.in/urfave/cli.v1"
 )
 
 var prospectCommand = cli.Command{


### PR DESCRIPTION
> This is the library formerly known as `github.com/codegangsta/cli`.
> GitHub will automatically redirect requests to this repository,
> but we recommend updating your references for clarity.

https://github.com/urfave/cli#pinning-to-the-v1-releases

> Avoid any unexpected compatibility pains once v2 becomes master by
> pinning to the latest tagged v1 release
> (e.g. v1.18.1 at the time of writing).

Also, update copyright year.